### PR TITLE
Fix ChatAnthropic ainvoke error by migrating to browser-use native LLM integration

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -1,8 +1,7 @@
 from typing import Awaitable, Callable
 from browser_use import Agent, Browser, BrowserConfig
 from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
-from langchain_anthropic import ChatAnthropic
+from browser_use.llm import ChatAnthropic
 import warnings
 
 load_dotenv()
@@ -15,7 +14,7 @@ browser = Browser(
     )
 )
 
-llm = ChatAnthropic(model_name="claude-3-5-sonnet-latest")
+llm = ChatAnthropic(model="claude-3-5-sonnet-latest")
 
 task_template = """
 perform the following task

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 browser-use
-langchain-anthropic
-langchain-openai
 python-dotenv
 fastmcp 
 mcp[cli]


### PR DESCRIPTION
## Summary

Updates imports to fix compatibility with browser-use v0.3.3+ after they dropped LangChain integration.

## What broke?

Running `uv run mcp dev server.py` throws:
```
ChatAnthropic object has no field ainvoke
```

The stdio communication fails with JSON parsing errors because browser-use v0.3.3 moved to their own LLM wrappers instead of using LangChain's.

## Fix

```diff
# browser.py
- from langchain_anthropic import ChatAnthropic
+ from browser_use.llm import ChatAnthropic

- ChatAnthropic(model_name="claude-3-5-sonnet-latest")
+ ChatAnthropic(model="claude-3-5-sonnet-latest")
```

Also cleaned up `requirements.txt` - removed `langchain-anthropic` and `langchain-openai` since browser-use handles this now.

## Tested

- MCP inspector starts without errors ✓
- No more ainvoke exceptions ✓
- One less dependency to worry about ✓

Related: https://github.com/browser-use/browser-use/issues/2134